### PR TITLE
docs: unify language switcher to badge-style separator

### DIFF
--- a/COOKBOOK.ja.md
+++ b/COOKBOOK.ja.md
@@ -1,5 +1,9 @@
 # レシピ集
 
+<p align="center">
+  | <a href="https://github.com/f-y/md-spreadsheet-parser/blob/main/COOKBOOK.md">English</a> | 日本語 |
+</p>
+
 このガイドでは、一般的なタスクに対する即座の解決策を提供します。
 
 ## 目次

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -1,5 +1,9 @@
 # Cookbook
 
+<p align="center">
+  | English | <a href="https://github.com/f-y/md-spreadsheet-parser/blob/main/COOKBOOK.ja.md">日本語</a> |
+</p>
+
 This guide provides immediate solutions for common tasks.
 
 ## Table of Contents

--- a/README.ja.md
+++ b/README.ja.md
@@ -20,6 +20,10 @@
 </p>
 
 <p align="center">
+  | <a href="https://github.com/f-y/md-spreadsheet-parser/blob/main/README.md">English</a> | 日本語 |
+</p>
+
+<p align="center">
   <strong>Markdownテーブル操作に特化したPythonライブラリ。ExcelからMarkdownへの変換、テーブルの解析、型安全な検証など。堅牢で依存関係ゼロ</strong>
 </p>
 
@@ -34,10 +38,6 @@
 > [![Get it on VS Code Marketplace](https://img.shields.io/badge/VS%20Code%20Marketplace-%E3%81%A7%E3%83%80%E3%82%A6%E3%83%B3%E3%83%AD%E3%83%BC%E3%83%89-007ACC?style=for-the-badge&logo=visual-studio-code&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=f-y.peng-sheets)
 
 🚀 **すぐに使いたいですか？** [Cookbook](https://github.com/f-y/md-spreadsheet-parser/blob/main/COOKBOOK.ja.md) には、コピー＆ペーストで使えるレシピ（Excel変換、Pandas連携、Markdownテーブル操作など）が満載です。
-
-<p align="center">
-  | <a href="https://github.com/f-y/md-spreadsheet-parser/blob/main/README.md">English</a> | 日本語 |
-</p>
 
 ## 目次
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -35,6 +35,10 @@
 
 🚀 **すぐに使いたいですか？** [Cookbook](https://github.com/f-y/md-spreadsheet-parser/blob/main/COOKBOOK.ja.md) には、コピー＆ペーストで使えるレシピ（Excel変換、Pandas連携、Markdownテーブル操作など）が満載です。
 
+<p align="center">
+  | <a href="https://github.com/f-y/md-spreadsheet-parser/blob/main/README.md">English</a> | 日本語 |
+</p>
+
 ## 目次
 
 - [機能](#機能)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
 </p>
 
 <p align="center">
+  | English | <a href="https://github.com/f-y/md-spreadsheet-parser/blob/main/README.ja.md">日本語</a> |
+</p>
+
+<p align="center">
   <strong>A robust, zero-dependency Python library for converting Excel to Markdown, parsing tables, and type-safe validation.</strong>
 </p>
 
@@ -34,10 +38,6 @@
 > [![Get it on VS Code Marketplace](https://img.shields.io/badge/Get%20it%20on-VS%20Code%20Marketplace-007ACC?style=for-the-badge&logo=visual-studio-code&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=f-y.peng-sheets)
 
 🚀 **Need a quick solution?** Check out the [Cookbook](https://github.com/f-y/md-spreadsheet-parser/blob/main/COOKBOOK.md) for copy-pasteable recipes (Excel conversion, Pandas integration, Markdown table manipulation, and more).
-
-<p align="center">
-  | English | <a href="https://github.com/f-y/md-spreadsheet-parser/blob/main/README.ja.md">日本語</a> |
-</p>
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@
 
 🚀 **Need a quick solution?** Check out the [Cookbook](https://github.com/f-y/md-spreadsheet-parser/blob/main/COOKBOOK.md) for copy-pasteable recipes (Excel conversion, Pandas integration, Markdown table manipulation, and more).
 
-Read in Japanese: 日本語版はこちら(
-<a href="https://github.com/f-y/md-spreadsheet-parser/blob/main/README.ja.md">README</a>, <a href="https://github.com/f-y/md-spreadsheet-parser/blob/main/COOKBOOK.ja.md">Cookbook</a>
-)
+<p align="center">
+  | English | <a href="https://github.com/f-y/md-spreadsheet-parser/blob/main/README.ja.md">日本語</a> |
+</p>
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary
- README / COOKBOOK の言語切替リンクを、peng-sheets と同じ `| English | 日本語 |` バッジスタイルに統一
- 日本語版 (README.ja.md, COOKBOOK.ja.md) にも同スタイルの言語切替リンクを追加

## Changes
- `README.md` — 旧形式の「日本語版はこちら」テキストをバッジスタイルに置換
- `COOKBOOK.md` — バッジスタイルの言語切替リンクを追加
- `README.ja.md` — バッジスタイルの言語切替リンクを追加
- `COOKBOOK.ja.md` — バッジスタイルの言語切替リンクを追加

## Test plan
- [ ] GitHub 上で各ファイルのレンダリングを確認し、リンクが正しく表示されることを確認